### PR TITLE
update Android's regex: allow parse OS version without minor version

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -838,7 +838,7 @@ os_parsers:
   # Android
   # can actually detect rooted android os. do we care?
   ##########
-  - regex: '(Android)[ \-/](\d+)\.(\d+)(?:[.\-]([a-z0-9]+))?'
+  - regex: '(Android)[ \-/](\d+)(?:\.(\d+))?(?:[.\-]([a-z0-9]+))?'
 
   - regex: '(Android) Donut'
     os_v1_replacement: '1'


### PR DESCRIPTION
### Background

From Android 9 (aka Android P) the UserAgent doesn't contain the minor
version (e.g. `Android 9`).
By that reason, we should allow parsing Android OS version without the
minor information.

### TODO

- [ ] check another Android regular expressions

### Ref

1. Chrome UserAgent on Android P Preview beta 3 (emulator)
![image](https://user-images.githubusercontent.com/1061090/43058357-340fe694-8e82-11e8-9e47-2ad39dd2b2ef.png)
